### PR TITLE
Refactor reliance on nodes as keys

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Callable, Optional, overload
+from bidict import bidict
 
 from ..utils.annotations import get_dependency, is_annotated
 
@@ -24,12 +25,45 @@ class Diagraph:
     error: Optional[Callable[[str, str, Key], None]]
     output: Optional[Result | list[Result]]
     results: DiagraphTraversalResults
-    fns: dict[Key, Fn]
+    fns: bidict[Key, Fn]
     __updated_refs__: dict[Fn, Fn]
+    graph_mapping: bidict[Fn, str]
 
-    def __init__(self, *terminal_nodes: Key, log=None, error=None) -> None:
-        self.__graph__ = Graph(build_graph(*terminal_nodes))
-        self.terminal_nodes = terminal_nodes
+    def __init__(
+        self, *terminal_nodes: Key, log=None, error=None, use_string_keys=False
+    ) -> None:
+        graph_def = build_graph(*terminal_nodes)
+        graph_mapping: dict[Fn, str] = dict()
+        graph_def_keys = list(graph_def.keys())
+
+        def get_fn_name(fn: Fn):
+            if use_string_keys:
+                return fn.__name__
+            return fn
+
+        for item in graph_def_keys:
+            val = graph_def[item]
+            graph_mapping[item] = get_fn_name(item)
+            new_val = set()
+            while len(val):
+                _item = val.pop()
+                # for _item in val:
+                graph_mapping[_item] = get_fn_name(_item)
+                # val.remove(_item)
+                new_val.add(get_fn_name(_item))
+
+            del graph_def[item]
+            graph_def[get_fn_name(item)] = new_val
+        self.graph_mapping = bidict(graph_mapping)
+        self.__graph__ = Graph(graph_def)
+        self.fns = {}
+
+        for key in self.__graph__.get_nodes():
+            self.fns[key] = self.graph_mapping.inverse[key]
+        self.fns = bidict(self.fns)
+        self.terminal_nodes = [
+            DiagraphNode(self, get_fn_name(node)) for node in terminal_nodes
+        ]
         self.log = log
         self.error = error
         self.results = DiagraphTraversalResults(self)
@@ -48,50 +82,44 @@ class Diagraph:
         ...
 
     def __getitem__(self, key: Fn | int) -> DiagraphNode | tuple[DiagraphNode]:
-        result = self.__graph__[key]
-        if isinstance(result, list):
-            nodes = [DiagraphNode(self, node) for node in result]
-            return tuple(nodes)
-        elif isinstance(key, Fn):
-            print("key", key)
-            return DiagraphNode(self, key)
-        raise Exception(f"Unknown type: {type(key)}")
+        node_keys = self.__graph__[key]
+        if isinstance(node_keys, list):
+            return tuple([DiagraphNode(self, node) for node in node_keys])
+        elif isinstance(node_keys, Fn) or isinstance(node_keys, str):
+            return DiagraphNode(self, node_keys)
+        raise Exception(f"Unknown type: {type(node_keys)}")
 
     def run(self, *input_args, **kwargs):
         return self.__run_from__(0, *input_args, **kwargs)
 
-    def __run_from__(self, key: Fn | int, *input_args, **kwargs):
-        node = self[key]
-        if not isinstance(node, tuple):
-            node = (node,)
-        starting_nodes = node
-        validate_node_ancestors(starting_nodes)
+    def __run_from__(self, node_key: Fn | int, *input_args, **kwargs):
+        nodes = self[node_key]  # nodes is a diagraph node
+        if not isinstance(nodes, tuple):
+            nodes = (nodes,)
+        validate_node_ancestors(nodes)
 
-        next_layer = set(starting_nodes)
         ran = set()
         try:
-            while next_layer:
+            while True:
                 layer = set()
-                # results: list[Result] = []
-                for node in next_layer:
+                for node in nodes:
                     if node not in ran:
                         ran.add(node)
-                        fn_key = node.fn
+                        fn_key = node.key
                         result = self.__run_node__(node, *input_args, **kwargs)
                         self.results[fn_key] = result
-                        # results.append(result)
                     if node.children:
                         for child in node.children:
                             layer.add(child)
 
                 if len(layer):
-                    next_layer = layer
+                    nodes = layer
                 else:
                     break
         except UserHandledException:
             pass
 
-        results = [self.results[node] for node in self.terminal_nodes]
+        results = [self.results[node.key] for node in self.terminal_nodes]
 
         if len(results) == 1:
             self.output = results[0]
@@ -103,12 +131,15 @@ class Diagraph:
     def __run_node__(self, node: Fn, *input_args, **kwargs):
         args = []
         arg_index = 0
-        fn = self.__updated_refs__.get(node.fn, node.fn)
+        fn = self.fns[node.key]
+        # fn = self.__updated_refs__.get(node.fn, node.fn)
+        # print("node", node, fn)
         for key, val in fn.__annotations__.items():
             if key != "return":
                 if is_annotated(val):
-                    dep = get_dependency(val)
-                    args.append(self.__get_result__(dep))
+                    dep: Fn = get_dependency(val)
+                    key_for_fn = self.fns.inverse[dep]
+                    args.append(self.__get_result__(key_for_fn))
                 else:
                     if arg_index > len(input_args) - 1:
                         raise Exception(f'No argument provided for "{key}"')
@@ -125,6 +156,6 @@ class Diagraph:
     def __update_ref__(self, old_fn_def: Fn, new_fn_def: Fn):
         self.__updated_refs__[old_fn_def] = new_fn_def
 
-    def __get_result__(self, key: Fn):
-        key = self.__updated_refs__.get(key, key)
+    def __get_result__(self, key: Key):
+        # key = self.__updated_refs__.get(key, key)
         return self.results[key]

--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -4,36 +4,35 @@ import tiktoken
 
 # To get the tokeniser corresponding to a specific model in the OpenAI API:
 from ..decorators.is_decorated import is_decorated
-from .types import Fn
-from .graph import Graph
+from .graph import Graph, Key
 
 
 class DiagraphNode:
     diagraph: Any
     __graph__: Graph
-    __key__: Fn
+    key: Key
 
-    def __init__(self, diagraph, key: Fn):
+    def __init__(self, diagraph, key: Key):
         self.diagraph = diagraph
         self.__graph__ = diagraph.__graph__
-        self.__key__ = key
+        self.key = key
 
     @property
     def fn(self):
-        return self.__graph__[self.__key__]
+        return self.diagraph.fns[self.key]
 
     @property
     def ancestors(self):
         return [
             DiagraphNode(self.diagraph, node)
-            for node in self.__graph__.out_edges(self.__key__)
+            for node in self.__graph__.out_edges(self.key)
         ]
 
     @property
     def children(self):
         return [
             DiagraphNode(self.diagraph, node)
-            for node in self.__graph__.in_edges(self.__key__)
+            for node in self.__graph__.in_edges(self.key)
         ]
 
     # @result.setter
@@ -64,12 +63,12 @@ class DiagraphNode:
             **kwargs,
         }
         for i, item in enumerate(self.fn.__annotations__.items()):
-            key, _ = item
-            if key != "return" and key not in kwargs:
+            ann_key, _ = item
+            if ann_key != "return" and ann_key not in kwargs:
                 if len(args) > 0 and args[i] is not None:
-                    kwargs[key] = args[i]
+                    kwargs[ann_key] = args[i]
                 else:
-                    kwargs[key] = f"{{{key}}}"
+                    kwargs[ann_key] = f"{{{ann_key}}}"
         return self.fn.__fn__(**kwargs)
 
     def tokens(self, *args, **kwargs):
@@ -79,22 +78,22 @@ class DiagraphNode:
         enc = tiktoken.encoding_for_model("gpt-4")
 
         for i, item in enumerate(self.fn.__annotations__.items()):
-            key, _ = item
-            if key != "return" and key not in kwargs:
+            ann_key, _ = item
+            if ann_key != "return" and ann_key not in kwargs:
                 if len(args) > 0 and args[i] is not None:
-                    kwargs[key] = args[i]
+                    kwargs[ann_key] = args[i]
                 else:
-                    kwargs[key] = ""
+                    kwargs[ann_key] = ""
         prompt = self.fn.__fn__(**kwargs)
         return len(enc.encode(prompt))
 
     def run(self, *input_args):
-        self.diagraph.__run_from__(self.fn, *input_args)
+        self.diagraph.__run_from__(self.key, *input_args)
 
     @property
     def result(self):
-        return self.diagraph.results[self.fn]
+        return self.diagraph.results[self.key]
 
     @result.setter
     def result(self, value):
-        self.diagraph.results[self.fn] = value
+        self.diagraph.results[self.key] = value

--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -4,16 +4,16 @@ import tiktoken
 
 # To get the tokeniser corresponding to a specific model in the OpenAI API:
 from ..decorators.is_decorated import is_decorated
-from .types import Node
+from .types import Fn
 from .graph import Graph
 
 
 class DiagraphNode:
     diagraph: Any
     __graph__: Graph
-    __key__: Node
+    __key__: Fn
 
-    def __init__(self, diagraph, key: Node):
+    def __init__(self, diagraph, key: Fn):
         self.diagraph = diagraph
         self.__graph__ = diagraph.__graph__
         self.__key__ = key

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -21,9 +21,9 @@ def describe_nodes():
         def foo():
             return "foo"
 
-        diagraph = Diagraph(foo)
+        diagraph = Diagraph(foo, use_string_keys=True)
 
-        node = diagraph[foo]
+        node = diagraph["foo"]
         assert isinstance(node, DiagraphNode)
         assert node.fn == foo
 
@@ -274,6 +274,7 @@ def describe_indexing():
 def describe_run():
     def test_it_can_run_a_single_fn(mocker):
         d0 = mocker.stub()
+        d0.__name__ = "d0"
 
         diagraph = Diagraph(d0)
 
@@ -726,11 +727,11 @@ def describe_replay():
         ):
             return f"{input}_{d1}-d2"
 
-        diagraph = Diagraph(d2)
+        diagraph = Diagraph(d2, use_string_keys=True)
 
-        diagraph[d1].result = "newresult"
+        diagraph["d1"].result = "newresult"
 
-        diagraph[d2].run("bar")
+        diagraph["d2"].run("bar")
         assert diagraph.output == "bar_newresult-d2"
 
     def test_it_modifies_result_and_can_replay_in_a_diamond():
@@ -757,11 +758,11 @@ def describe_replay():
                 ]
             )
 
-        diagraph = Diagraph(d2).run("foo")
+        diagraph = Diagraph(d2, use_string_keys=True).run("foo")
 
-        diagraph[d0].result = "newresult"
+        diagraph["d0"].result = "newresult"
 
-        diagraph[d1a].run("bar")
+        diagraph["d1a"].run("bar")
 
         assert diagraph.output == "*".join(
             [

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -790,7 +790,7 @@ def describe_replay():
     #     def new_fn(input: str):
     #         return f"newfn{input}"
 
-    #     diagraph[d0] = new_fn
+    #     diagraph["d0"] = new_fn
 
     #     diagraph.run("bar")
     #     assert diagraph.output == "bar_newfnbar-d1-d2_bar"

--- a/packages/python/diagraph/classes/graph.py
+++ b/packages/python/diagraph/classes/graph.py
@@ -3,24 +3,18 @@ from typing import Generic, TypeVar
 import networkx as nx
 from ..utils.build_graph import build_depth_map
 
-T = TypeVar("T")
+Key = TypeVar("Key")
 
 
-class Graph(Generic[T]):
+class Graph(Generic[Key]):
     __G__: nx.DiGraph
-    __key_to_int__: dict[T, int]
-    graph_def: dict[T, T]
-    depth_map_by_depth: dict[int, list[T]]
+    __key_to_int__: dict[Key, int]
+    graph_def: dict[Key, Key]
+    depth_map_by_depth: dict[int, list[Key]]
 
-    def __init__(self, graph_def: dict[T, T]):
+    def __init__(self, graph_def: dict[Key, Key]):
         self.graph_def = graph_def
         self.__key_to_int__ = {}
-        # for key, val in graph.items():
-        #     if isinstance(key, int):
-        #         raise Exception("Keys must not be integers")
-        #     for value in val:
-        #         if isinstance(value, int):
-        #             raise Exception("Values must not be integers")
         self.__G__ = nx.convert_node_labels_to_integers(
             nx.DiGraph(self.graph_def), label_attribute="ref"
         )
@@ -31,13 +25,13 @@ class Graph(Generic[T]):
             ref = self.__G__.nodes[int_representation]["ref"]
             self.__key_to_int__[ref] = int_representation
 
-    def get_key_for_node(self, node: T) -> int:
+    def get_key_for_node(self, node: Key) -> int:
         return self.__key_to_int__[node]
 
     def get_node_for_key(self, key: int):
         return self.__G__.nodes[key]["ref"]
 
-    def __getitem__(self, key: T):
+    def __getitem__(self, key: Key):
         if isinstance(key, slice):
             if key.step is not None:
                 raise Exception("Slicing with a step is not supported")
@@ -58,7 +52,7 @@ class Graph(Generic[T]):
         int_rep = self.__key_to_int__[key]
         return self.get_node_for_key(int_rep)
 
-    def __setitem__(self, old: T, new: T):
+    def __setitem__(self, old: Key, new: Key):
         # print(self.__key_to_int__)
         # print("old", old, "new", new)
         self.__key_to_int__[new] = self.__key_to_int__[old]
@@ -68,12 +62,12 @@ class Graph(Generic[T]):
     def to_json(self):
         return nx.node_link_data(self.__G__)
 
-    def in_edges(self, key: T):
+    def in_edges(self, key: Key):
         key = self.get_key_for_node(key)
         int_representations = [i for i, _ in list(self.__G__.in_edges(key))]
         return [self.get_node_for_key(i) for i in int_representations]
 
-    def out_edges(self, key: T):
+    def out_edges(self, key: Key):
         key = self.get_key_for_node(key)
         int_representations = [i for _, i in list(self.__G__.out_edges(key))]
         return [self.get_node_for_key(i) for i in int_representations]

--- a/packages/python/diagraph/classes/graph.py
+++ b/packages/python/diagraph/classes/graph.py
@@ -25,13 +25,16 @@ class Graph(Generic[Key]):
             ref = self.__G__.nodes[int_representation]["ref"]
             self.__key_to_int__[ref] = int_representation
 
-    def get_key_for_node(self, node: Key) -> int:
-        return self.__key_to_int__[node]
+    def get_nodes(self):
+        return [self.__G__.nodes[int_rep]["ref"] for int_rep in self.__G__.nodes()]
 
-    def get_node_for_key(self, key: int):
+    def get_int_key_for_node(self, key: Key) -> int:
+        return self.__key_to_int__[key]
+
+    def get_node_for_int_key(self, key: int):
         return self.__G__.nodes[key]["ref"]
 
-    def __getitem__(self, key: Key):
+    def __getitem__(self, key: Key | int | slice):
         if isinstance(key, slice):
             if key.step is not None:
                 raise Exception("Slicing with a step is not supported")
@@ -47,10 +50,10 @@ class Graph(Generic[Key]):
             if key < 0:
                 key = max(self.depth_map_by_depth.keys()) + 1 + key
             nodes_at_depth = self.depth_map_by_depth[key]
-            return [self.get_node_for_key(int_rep) for int_rep in nodes_at_depth]
+            return [self.get_node_for_int_key(int_rep) for int_rep in nodes_at_depth]
 
         int_rep = self.__key_to_int__[key]
-        return self.get_node_for_key(int_rep)
+        return self.get_node_for_int_key(int_rep)
 
     def __setitem__(self, old: Key, new: Key):
         # print(self.__key_to_int__)
@@ -63,11 +66,11 @@ class Graph(Generic[Key]):
         return nx.node_link_data(self.__G__)
 
     def in_edges(self, key: Key):
-        key = self.get_key_for_node(key)
+        key = self.get_int_key_for_node(key)
         int_representations = [i for i, _ in list(self.__G__.in_edges(key))]
-        return [self.get_node_for_key(i) for i in int_representations]
+        return [self.get_node_for_int_key(i) for i in int_representations]
 
     def out_edges(self, key: Key):
-        key = self.get_key_for_node(key)
+        key = self.get_int_key_for_node(key)
         int_representations = [i for _, i in list(self.__G__.out_edges(key))]
-        return [self.get_node_for_key(i) for i in int_representations]
+        return [self.get_node_for_int_key(i) for i in int_representations]

--- a/packages/python/diagraph/classes/graph_test.py
+++ b/packages/python/diagraph/classes/graph_test.py
@@ -11,8 +11,14 @@ def test_it_builds_connected_directed_graph():
 
     dump = graph.to_json()
     assert dump.get("links") == [
-        {"source": graph.get_key_for_node("a"), "target": graph.get_key_for_node("b")},
-        {"source": graph.get_key_for_node("b"), "target": graph.get_key_for_node("c")},
+        {
+            "source": graph.get_int_key_for_node("a"),
+            "target": graph.get_int_key_for_node("b"),
+        },
+        {
+            "source": graph.get_int_key_for_node("b"),
+            "target": graph.get_int_key_for_node("c"),
+        },
     ]
 
 
@@ -55,8 +61,14 @@ def test_it_can_update_nodes():
 
     dump = graph.to_json()
     assert dump.get("links") == [
-        {"source": graph.get_key_for_node("d"), "target": graph.get_key_for_node("b")},
-        {"source": graph.get_key_for_node("b"), "target": graph.get_key_for_node("c")},
+        {
+            "source": graph.get_int_key_for_node("d"),
+            "target": graph.get_int_key_for_node("b"),
+        },
+        {
+            "source": graph.get_int_key_for_node("b"),
+            "target": graph.get_int_key_for_node("c"),
+        },
     ]
 
 
@@ -88,16 +100,22 @@ def test_it_returns_a_copy_of_itself():
     graph_2["a"] = "e"
 
     assert graph.to_json().get("links") == [
-        {"source": graph.get_key_for_node("d"), "target": graph.get_key_for_node("b")},
-        {"source": graph.get_key_for_node("b"), "target": graph.get_key_for_node("c")},
+        {
+            "source": graph.get_int_key_for_node("d"),
+            "target": graph.get_int_key_for_node("b"),
+        },
+        {
+            "source": graph.get_int_key_for_node("b"),
+            "target": graph.get_int_key_for_node("c"),
+        },
     ]
     assert graph_2.to_json().get("links") == [
         {
-            "source": graph_2.get_key_for_node("e"),
-            "target": graph_2.get_key_for_node("b"),
+            "source": graph_2.get_int_key_for_node("e"),
+            "target": graph_2.get_int_key_for_node("b"),
         },
         {
-            "source": graph_2.get_key_for_node("b"),
-            "target": graph_2.get_key_for_node("c"),
+            "source": graph_2.get_int_key_for_node("b"),
+            "target": graph_2.get_int_key_for_node("c"),
         },
     ]

--- a/packages/python/diagraph/classes/results.py
+++ b/packages/python/diagraph/classes/results.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any
 
-from .types import Node
+from .types import Fn
 
 
 class DiagraphTraversalResults:
@@ -12,10 +12,10 @@ class DiagraphTraversalResults:
         self.__traversal__ = traversal
         self.__results__ = {}
 
-    def __getitem__(self, key: Node) -> Any:
+    def __getitem__(self, key: Fn) -> Any:
         int_rep = self.__traversal__.__graph__.get_key_for_node(key)
         return self.__results__.get(int_rep)
 
-    def __setitem__(self, key: Node, val: Any) -> Any:
+    def __setitem__(self, key: Fn, val: Any) -> Any:
         int_rep = self.__traversal__.__graph__.get_key_for_node(key)
         self.__results__[int_rep] = val

--- a/packages/python/diagraph/classes/results.py
+++ b/packages/python/diagraph/classes/results.py
@@ -13,9 +13,9 @@ class DiagraphTraversalResults:
         self.__results__ = {}
 
     def __getitem__(self, key: Fn) -> Any:
-        int_rep = self.__traversal__.__graph__.get_key_for_node(key)
+        int_rep = self.__traversal__.__graph__.get_int_key_for_node(key)
         return self.__results__.get(int_rep)
 
     def __setitem__(self, key: Fn, val: Any) -> Any:
-        int_rep = self.__traversal__.__graph__.get_key_for_node(key)
+        int_rep = self.__traversal__.__graph__.get_int_key_for_node(key)
         self.__results__[int_rep] = val

--- a/packages/python/diagraph/classes/types.py
+++ b/packages/python/diagraph/classes/types.py
@@ -1,5 +1,5 @@
 from typing import Callable, Any
 
-Node = Callable
+Fn = Callable
 
 Result = Any

--- a/packages/python/diagraph/utils/annotations.py
+++ b/packages/python/diagraph/utils/annotations.py
@@ -1,6 +1,5 @@
 from typing import Annotated, Any, Callable
-from ..classes.types import Node
-
+from ..classes.types import Fn
 
 
 def is_annotated(val: Any):
@@ -15,5 +14,5 @@ def get_annotations(node: Callable):
             yield key, val
 
 
-def get_dependency(val: Annotated) -> Node:
+def get_dependency(val: Annotated) -> Fn:
     return val.__metadata__[0].dependency

--- a/packages/python/diagraph/utils/validate_node_ancestors.py
+++ b/packages/python/diagraph/utils/validate_node_ancestors.py
@@ -1,7 +1,7 @@
-from ..classes.types import Node
+from ..classes.types import Fn
 
 
-def validate_node_ancestors(nodes: tuple[Node]):
+def validate_node_ancestors(nodes: tuple[Fn]):
     for node in nodes:
         for ancestor in node.ancestors:
             if ancestor.result is None:

--- a/packages/python/diagraph/utils/validate_node_ancestors.py
+++ b/packages/python/diagraph/utils/validate_node_ancestors.py
@@ -1,7 +1,7 @@
-from ..classes.types import Fn
+from ..classes.diagraph_node import DiagraphNode
 
 
-def validate_node_ancestors(nodes: tuple[Fn]):
+def validate_node_ancestors(nodes: tuple[DiagraphNode]):
     for node in nodes:
         for ancestor in node.ancestors:
             if ancestor.result is None:

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "llm",
   "networkx",
   "tiktoken",
+  "bidict",
 ]
 description = "DAGs for LLM interactions"
 classifiers = [


### PR DESCRIPTION
Disambiguate the concept of "key" and "node".

While nodes are used as keys, they shouldn't _have_ to be. We should maintain an internal dictionary of "key' -> "node" to support in the future alternate key schemes.