### PR TITLE
Save fns as a historical record

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Generic, Optional, TypeVar, overload
+from typing import Callable, Optional, overload
 from bidict import bidict
 
 from ..utils.annotations import get_dependency, is_annotated

--- a/packages/python/diagraph/classes/historical_bidict.py
+++ b/packages/python/diagraph/classes/historical_bidict.py
@@ -1,0 +1,23 @@
+from typing import Generic, TypeVar
+
+Key = TypeVar("Key")
+Value = TypeVar("Value")
+
+
+class HistoricalBidict(Generic[Key, Value]):
+    keys: dict[Key, list[Value]]
+    values_to_keys: dict[Value, Key]
+
+    def __init__(self):
+        self.keys = {}
+        self.values_to_keys = {}
+
+    def __setitem__(self, key: Key, value: Value):
+        self.keys[key] = self.keys.get(key, []) + [value]
+        self.values_to_keys[value] = key
+
+    def __getitem__(self, key: Key):
+        return self.keys[key][-1]
+
+    def inverse(self, value: Value):
+        return self.values_to_keys[value]


### PR DESCRIPTION
Introduces a class, `HistoricalBidict`, that stores a mapping from `key` -> `list[value]`. 

This will allow `diagraph`s to maintain a record of their current state as well as their historical state, which I expect will be useful.