### PR TITLE
Fix top level export

### DIFF
--- a/packages/python/diagraph/__init__.py
+++ b/packages/python/diagraph/__init__.py
@@ -1,4 +1,4 @@
-from .diagraph import Diagraph as Diagraph
-from .prompt import prompt as prompt
+from .classes.diagraph import Diagraph as Diagraph
+from .decorators.prompt import prompt as prompt
 from .llm.openai_llm import OpenAI as OpenAI
 from .utils.depends import Depends as Depends

--- a/packages/python/diagraph/__init__.py
+++ b/packages/python/diagraph/__init__.py
@@ -1,0 +1,4 @@
+from .diagraph import Diagraph as Diagraph
+from .prompt import prompt as prompt
+from .llm.openai_llm import OpenAI as OpenAI
+from .utils.depends import Depends as Depends

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diagraph"
-version = "0.0.8.rc1"
+version = "0.0.8.rc2"
 # Notes
 authors = [{ name = "Kevin Scott", email = "kevin@diagraph.dev" }]
 readme = "README.md"

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diagraph"
-version = "0.0.8"
+version = "0.0.8.rc1"
 # Notes
 authors = [{ name = "Kevin Scott", email = "kevin@diagraph.dev" }]
 readme = "README.md"

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diagraph"
-version = "0.0.8.rc2"
+version = "0.0.8.rc3"
 # Notes
 authors = [{ name = "Kevin Scott", email = "kevin@diagraph.dev" }]
 readme = "README.md"


### PR DESCRIPTION
#17 implemented this, but `ruff` removed them as I wrote them incorrectly. This should bring them back.