### PR TITLE
Fix @prompt and enable layer `result` and `prompt`

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -14,7 +14,7 @@ from ..utils.validate_node_ancestors import validate_node_ancestors
 from ..utils.build_graph import build_graph
 
 from .graph import Graph, Key
-from .types import Fn, Result
+from .types import Fn
 
 from .diagraph_node import DiagraphNode
 

--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -108,7 +108,6 @@ class Diagraph:
                     if node not in ran:
                         ran.add(node)
                         result = self.__run_node__(node, *input_args, **kwargs)
-                        print("set result for", node)
                         node.result = result
                     if node.children:
                         for child in node.children:
@@ -145,7 +144,6 @@ class Diagraph:
                 if is_annotated(val):
                     dep: Fn = get_dependency(val)
                     key_for_fn = self.fns.inverse(dep)
-                    print("get result for", key_for_fn, "because of node", node)
                     args.append(self.results[key_for_fn])
                 else:
                     if arg_index > len(input_args) - 1:

--- a/packages/python/diagraph/classes/diagraph_layer.py
+++ b/packages/python/diagraph/classes/diagraph_layer.py
@@ -6,15 +6,16 @@ from .graph import Key
 
 class DiagraphLayer:
     diagraph: Any
-    nodes: list[DiagraphNode]
+    nodes: tuple[DiagraphNode]
     key: int
 
     def __init__(self, diagraph: Any, key: int, *node_keys: Key):
         self.diagraph = diagraph
-        self.nodes = []
         self.key = key
+        nodes = []
         for node in node_keys:
-            self.nodes.append(DiagraphNode(self.diagraph, node))
+            nodes.append(DiagraphNode(self.diagraph, node))
+        self.nodes = tuple(nodes)
 
     def __iter__(self):
         return iter(self.nodes)
@@ -45,3 +46,29 @@ class DiagraphLayer:
 
     def run(self, *input_args, **kwargs):
         self.diagraph.__run_from__(self.key, *input_args, **kwargs)
+
+    @property
+    def result(self):
+        results = []
+        for node in self.nodes:
+            results.append(self.diagraph.results[node.key])
+        if len(results) == 1:
+            return results[0]
+        return tuple(results)
+
+    @result.setter
+    def result(self, values):
+        if isinstance(values, str):
+            if len(self.nodes) != 1:
+                raise Exception(
+                    f"You provided a string as a value but the layer has {len(self.nodes)} nodes. Setting a string value is only supported for a single node. Instead, provide a tuple of values matching of length {len(self.nodes)}"
+                )
+            self.diagraph.results[self.nodes[0].key] = values
+        else:
+            if len(self.nodes) != len(values):
+                raise Exception(
+                    f"Number of results ({len(values)}) does not match number of nodes ({len(self.nodes)})"
+                )
+
+            for node, value in zip(self.nodes, values):
+                self.diagraph.results[node.key] = value

--- a/packages/python/diagraph/classes/diagraph_layer.py
+++ b/packages/python/diagraph/classes/diagraph_layer.py
@@ -56,6 +56,14 @@ class DiagraphLayer:
             return results[0]
         return tuple(results)
 
+    def prompt(self, *args, **kwargs):
+        prompts = []
+        for node in self.nodes:
+            prompts.append(node.prompt(*args, **kwargs))
+        if len(prompts) == 1:
+            return prompts[0]
+        return tuple(prompts)
+
     @result.setter
     def result(self, values):
         if isinstance(values, str):

--- a/packages/python/diagraph/classes/diagraph_layer_test.py
+++ b/packages/python/diagraph/classes/diagraph_layer_test.py
@@ -65,3 +65,38 @@ def describe_diagraph_layer():
         assert d0 not in layer
         assert d1 in layer
         assert d2 in layer
+
+    def test_it_can_return_results():
+        def d0():
+            return "d0"
+
+        def d1(d0: Annotated[str, Depends(d0)]):
+            return "d1"
+
+        def d2(d0: Annotated[str, Depends(d0)]):
+            return "d2"
+
+        diagraph = Diagraph(d1, d2).run()
+        assert diagraph[0].result == "d0"
+        assert diagraph[1].result == ("d1", "d2")
+
+    def test_it_can_set_results():
+        def d0():
+            return "d0"
+
+        def d1(d0: Annotated[str, Depends(d0)]):
+            return f"{d0} d1"
+
+        def d2(d0: Annotated[str, Depends(d0)]):
+            return f"{d0} d2"
+
+        diagraph = Diagraph(d1, d2).run()
+        assert diagraph.output == ("d0 d1", "d0 d2")
+        diagraph[0].result = "foo"
+        diagraph.run()
+        assert diagraph.output == ("foo d1", "foo d2")
+        diagraph[1].result = ("bar", "baz")
+        assert diagraph[0].result == "foo"
+        assert diagraph[1].result == ("bar", "baz")
+        diagraph.run()
+        assert diagraph.output == ("bar", "baz")

--- a/packages/python/diagraph/classes/diagraph_layer_test.py
+++ b/packages/python/diagraph/classes/diagraph_layer_test.py
@@ -93,10 +93,9 @@ def describe_diagraph_layer():
         diagraph = Diagraph(d1, d2).run()
         assert diagraph.output == ("d0 d1", "d0 d2")
         diagraph[0].result = "foo"
-        diagraph.run()
+        diagraph[1].run()
         assert diagraph.output == ("foo d1", "foo d2")
         diagraph[1].result = ("bar", "baz")
         assert diagraph[0].result == "foo"
         assert diagraph[1].result == ("bar", "baz")
-        diagraph.run()
         assert diagraph.output == ("bar", "baz")

--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -3,7 +3,7 @@ from typing import Any
 import tiktoken
 
 # To get the tokeniser corresponding to a specific model in the OpenAI API:
-from ..decorators.is_decorated import is_decorated
+from ..decorators.is_decorated import IS_DECORATED_KEY, is_decorated
 from .graph import Graph, Key
 
 
@@ -52,7 +52,10 @@ class DiagraphNode:
 
     #     # return inspect.getsource(self.fn)
 
-    def _is_decorated_(self):
+    @property
+    def __is_decorated__(self):
+        # print(self.fn, IS_DECORATED_KEY)
+        # print(getattr(self.fn, IS_DECORATED_KEY, False))
         return is_decorated(self.fn)
 
     # def __getattribute__(self, __name__: str) -> Any:
@@ -65,7 +68,7 @@ class DiagraphNode:
     #         return "foo"
 
     def prompt(self, *args, **kwargs):
-        if self._is_decorated_() is False:
+        if self.__is_decorated__ is False:
             raise Exception("This function has not been decorated with @prompt")
 
         kwargs = {
@@ -81,7 +84,7 @@ class DiagraphNode:
         return self.fn.__fn__(**kwargs)
 
     def tokens(self, *args, **kwargs):
-        if self._is_decorated_() is False:
+        if self.__is_decorated__ is False:
             raise Exception("This function has not been decorated with @prompt")
 
         enc = tiktoken.encoding_for_model("gpt-4")

--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -3,7 +3,7 @@ from typing import Any
 import tiktoken
 
 # To get the tokeniser corresponding to a specific model in the OpenAI API:
-from ..decorators.is_decorated import IS_DECORATED_KEY, is_decorated
+from ..decorators.is_decorated import is_decorated
 from .graph import Graph, Key
 
 

--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -38,7 +38,6 @@ class DiagraphNode:
     @property
     def depth(self):
         int_key = self.diagraph.__graph__.get_int_key_for_node(self.key)
-        print(self.diagraph.__graph__.depth_map_by_key)
         # if self.key not in self.diagraph.__graph__.depth_map_by_key:
         #     raise Exception(f"Key {self.key} not in depth map")
         return self.diagraph.__graph__.depth_map_by_key[int_key]

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -566,7 +566,7 @@ def describe_inputs():
     def test_it_does_a_real_world_example(mocker):
         class MockLLM:
             def run(self, string, log, stream=None, **kwargs):
-                return string
+                return string + "_"
 
         @prompt(llm=MockLLM())
         def tell_me_a_joke():
@@ -583,7 +583,14 @@ def describe_inputs():
         ) -> str:
             return f"{joke} {explanation} improve"
 
-        assert Diagraph(improvement).run().output == "joke joke explain improve"
+        diagraph = Diagraph(improvement).run()
+        assert diagraph.output == "joke_ joke_ explain_ improve_"
+        assert diagraph[0].result == "joke"
+        assert diagraph[1].result == "joke _ explain"
+        assert diagraph[2].result == diagraph.output
+        assert diagraph[0].prompt() == "joke"
+        assert diagraph[1].prompt() == "{{joke}} explain"
+        assert diagraph[2].prompt() == "{{joke}} {{explanation}} improve"
 
 
 def describe_running_from_an_index():

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -1,5 +1,5 @@
 from typing import Annotated
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 import pytest
 from ..llm.openai_llm import OpenAI
 
@@ -575,7 +575,7 @@ def describe_inputs():
                 OpenAI,
                 "run",
                 fake_run,
-            ) as mocked_function_to_patch:
+            ):
 
                 @prompt
                 def tell_me_a_joke():

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -1,5 +1,8 @@
 from typing import Annotated
+from unittest.mock import patch, Mock
 import pytest
+from ..llm.openai_llm import OpenAI
+
 
 from .diagraph_layer import DiagraphLayer
 from .diagraph import Diagraph
@@ -563,34 +566,107 @@ def describe_inputs():
             == "foo_foo_foo_d0-d1a_bar-foo_foo_d0-d1b-d2_bar"
         )
 
-    def test_it_does_a_real_world_example(mocker):
-        class MockLLM:
-            def run(self, string, log, stream=None, **kwargs):
+    def describe_real_world_example():
+        def test_it_does_a_real_world_example_with_non_prompt_fn():
+            def fake_run(self, string, stream=None, **kwargs):
                 return string + "_"
 
-        @prompt(llm=MockLLM())
-        def tell_me_a_joke():
-            return "joke"
+            with patch.object(
+                OpenAI,
+                "run",
+                fake_run,
+            ) as mocked_function_to_patch:
 
-        @prompt(llm=MockLLM())
-        def explanation(joke: Annotated[str, Depends(tell_me_a_joke)]) -> str:
-            return f"{joke} explain"
+                @prompt
+                def tell_me_a_joke():
+                    return "joke"
 
-        @prompt(llm=MockLLM())
-        def improvement(
-            joke: Annotated[str, Depends(tell_me_a_joke)],
-            explanation: Annotated[str, Depends(explanation)],
-        ) -> str:
-            return f"{joke} {explanation} improve"
+                @prompt
+                def explanation(joke: Annotated[str, Depends(tell_me_a_joke)]) -> str:
+                    return f"{joke} explain"
 
-        diagraph = Diagraph(improvement).run()
-        assert diagraph.output == "joke_ joke_ explain_ improve_"
-        assert diagraph[0].result == "joke"
-        assert diagraph[1].result == "joke _ explain"
-        assert diagraph[2].result == diagraph.output
-        assert diagraph[0].prompt() == "joke"
-        assert diagraph[1].prompt() == "{{joke}} explain"
-        assert diagraph[2].prompt() == "{{joke}} {{explanation}} improve"
+                @prompt
+                def improvement(
+                    joke: Annotated[str, Depends(tell_me_a_joke)],
+                    explanation: Annotated[str, Depends(explanation)],
+                ) -> str:
+                    return f"{joke} {explanation} improve"
+
+                diagraph = Diagraph(improvement).run()
+                assert diagraph.output == "joke_ joke_ explain_ improve_"
+                assert diagraph[tell_me_a_joke].result == "joke_"
+                assert diagraph[explanation].result == "joke_ explain_"
+                assert diagraph[improvement].result == diagraph.output
+                assert diagraph[0].result == "joke_"
+                assert diagraph[1].result == "joke_ explain_"
+                assert diagraph[2].result == diagraph.output
+                assert diagraph[-3].result == "joke_"
+                assert diagraph[-2].result == "joke_ explain_"
+                assert diagraph[-1].result == diagraph.output
+                assert diagraph[tell_me_a_joke].prompt() == "joke"
+                assert diagraph[explanation].prompt() == "{joke} explain"
+                assert diagraph[improvement].prompt() == "{joke} {explanation} improve"
+                assert diagraph[0].prompt() == "joke"
+                assert diagraph[1].prompt() == "{joke} explain"
+                assert diagraph[2].prompt() == "{joke} {explanation} improve"
+                assert diagraph[-3].prompt() == "joke"
+                assert diagraph[-2].prompt() == "{joke} explain"
+                assert diagraph[-1].prompt() == "{joke} {explanation} improve"
+
+                assert diagraph[explanation].prompt("foo") == "foo explain"
+                assert diagraph[improvement].prompt("foo", "bar") == "foo bar improve"
+                assert diagraph[1].prompt("foo") == "foo explain"
+                assert diagraph[2].prompt("foo", "bar") == "foo bar improve"
+                assert diagraph[-2].prompt("foo") == "foo explain"
+                assert diagraph[-1].prompt("foo", "bar") == "foo bar improve"
+
+        def test_it_does_a_real_world_example_with_prompt_fn(mocker):
+            class MockLLM:
+                def run(self, string, log, stream=None, **kwargs):
+                    return string + "_"
+
+            @prompt(llm=MockLLM())
+            def tell_me_a_joke():
+                return "joke"
+
+            @prompt(llm=MockLLM())
+            def explanation(joke: Annotated[str, Depends(tell_me_a_joke)]) -> str:
+                return f"{joke} explain"
+
+            @prompt(llm=MockLLM())
+            def improvement(
+                joke: Annotated[str, Depends(tell_me_a_joke)],
+                explanation: Annotated[str, Depends(explanation)],
+            ) -> str:
+                return f"{joke} {explanation} improve"
+
+            diagraph = Diagraph(improvement).run()
+            assert diagraph.output == "joke_ joke_ explain_ improve_"
+            assert diagraph[tell_me_a_joke].result == "joke_"
+            assert diagraph[explanation].result == "joke_ explain_"
+            assert diagraph[improvement].result == diagraph.output
+            assert diagraph[0].result == "joke_"
+            assert diagraph[1].result == "joke_ explain_"
+            assert diagraph[2].result == diagraph.output
+            assert diagraph[-3].result == "joke_"
+            assert diagraph[-2].result == "joke_ explain_"
+            assert diagraph[-1].result == diagraph.output
+            assert diagraph[tell_me_a_joke].prompt() == "joke"
+            assert diagraph[explanation].prompt() == "{joke} explain"
+            assert diagraph[improvement].prompt() == "{joke} {explanation} improve"
+            assert diagraph[0].prompt() == "joke"
+            assert diagraph[1].prompt() == "{joke} explain"
+            assert diagraph[2].prompt() == "{joke} {explanation} improve"
+            assert diagraph[-3].prompt() == "joke"
+            assert diagraph[-2].prompt() == "{joke} explain"
+            assert diagraph[-1].prompt() == "{joke} {explanation} improve"
+
+            assert diagraph[explanation].prompt("foo") == "foo explain"
+            assert diagraph[improvement].prompt("foo", "bar") == "foo bar improve"
+            assert diagraph[1].prompt("foo") == "foo explain"
+            assert diagraph[2].prompt("foo", "bar") == "foo bar improve"
+            assert diagraph[-2].prompt("foo") == "foo explain"
+            assert diagraph[-1].prompt("foo", "bar") == "foo bar improve"
 
 
 def describe_running_from_an_index():

--- a/packages/python/diagraph/classes/graph_test.py
+++ b/packages/python/diagraph/classes/graph_test.py
@@ -96,7 +96,6 @@ def test_it_returns_a_copy_of_itself():
     graph_2 = graph[:]
 
     graph["a"] = "d"
-    print(graph_2)
     graph_2["a"] = "e"
 
     assert graph.to_json().get("links") == [

--- a/packages/python/diagraph/decorators/prompt.py
+++ b/packages/python/diagraph/decorators/prompt.py
@@ -12,6 +12,8 @@ def prompt(_func=None, *, log=None, llm=None, error=None, return_type=None):
         llm = OpenAI()
 
     def decorator(func):
+        # print(func)
+
         @functools.wraps(func)
         def wrapper_fn(*args, **kwargs):
             diagraph_log = getattr(wrapper_fn, "__log__", None)
@@ -37,12 +39,12 @@ def prompt(_func=None, *, log=None, llm=None, error=None, return_type=None):
                 else:
                     raise e
 
+        setattr(wrapper_fn, IS_DECORATED_KEY, True)
+        setattr(wrapper_fn, "__fn__", func)
         return wrapper_fn
 
     if _func is None:
         # Being called with arguments
-        setattr(decorator, IS_DECORATED_KEY, True)
-        setattr(decorator, "__fn__", _func)
         return decorator
     else:
         setattr(_func, IS_DECORATED_KEY, True)

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diagraph"
-version = "0.0.8.rc4"
+version = "0.1.0"
 # Notes
 authors = [{ name = "Kevin Scott", email = "kevin@diagraph.dev" }]
 readme = "README.md"


### PR DESCRIPTION
Introduces the concept of a `run` stored on the diagraph, which lets us grab intermediary records and build `output` on the fly.

Also adds a test for `@prompt` and fixes an issue where `@prompt()` was not being recognized.

Also enables `DiagraphLayer` to respond to `result` and `prompt` requests.