### PR TITLE
Handle setting inverse values that are non-hashable

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -14,7 +14,7 @@ from ..utils.validate_node_ancestors import validate_node_ancestors
 from ..utils.build_graph import build_graph
 
 from .graph import Graph, Key
-from .types import Fn, Result
+from .types import Fn
 
 from .diagraph_node import DiagraphNode
 

--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -14,7 +14,7 @@ from ..utils.validate_node_ancestors import validate_node_ancestors
 from ..utils.build_graph import build_graph
 
 from .graph import Graph, Key
-from .types import Fn
+from .types import Fn, Result
 
 from .diagraph_node import DiagraphNode
 
@@ -174,8 +174,6 @@ class Diagraph:
         if latest_run is None:
             raise Exception("Diagraph has not been run yet")
         if latest_run.get("complete"):
-            # print("complete")
-            # print(self.terminal_nodes)
             results = [node.result for node in self.terminal_nodes]
         else:
             latest_depth = latest_run.get("active_depth")

--- a/packages/python/diagraph/classes/historical_bidict.py
+++ b/packages/python/diagraph/classes/historical_bidict.py
@@ -3,6 +3,8 @@ from typing import Generic, TypeVar
 Key = TypeVar("Key")
 Value = TypeVar("Value")
 
+def is_not_hashable(value):
+    return isinstance(value, (list, dict, set))
 
 class HistoricalBidict(Generic[Key, Value]):
     keys: dict[Key, list[Value]]
@@ -14,12 +16,17 @@ class HistoricalBidict(Generic[Key, Value]):
 
     def __setitem__(self, key: Key, value: Value):
         self.keys[key] = self.keys.get(key, []) + [value]
-        self.values_to_keys[value] = key
+        if is_not_hashable(value):
+            self.values_to_keys[str(value)] = key
+        else:
+            self.values_to_keys[value] = key
 
     def __getitem__(self, key: Key):
         return self.keys[key][-1]
 
     def inverse(self, value: Value):
+        if is_not_hashable(value):
+            return self.values_to_keys[str(value)]
         return self.values_to_keys[value]
 
     def historical(self, key: Key, index: int):

--- a/packages/python/diagraph/classes/historical_bidict_test.py
+++ b/packages/python/diagraph/classes/historical_bidict_test.py
@@ -21,3 +21,22 @@ def describe_historical_bidict():
         assert hdict["foo"] == "baz"
         assert hdict.historical("foo", -1) == "baz"
         assert hdict.historical("foo", -2) == "bar"
+
+    def test_it_appends_all_kinds_of_data():
+        hdict = HistoricalBidict()
+        class FakeClass:
+            pass
+        for key, value in [
+            ("int", 1),
+            ("float", 1.5),
+            ("tuple", (1,2,3)),
+            ("list", [1,2,3]),
+            ("dict", { "foo": "bar" }),
+            ("set", set([1,2,3])),
+            ("frozenset", frozenset([1,2,3])),
+            ("class_def", FakeClass),
+            ("instantiated_class", FakeClass()),
+        ]:
+            hdict[key] = value
+            assert hdict.inverse(value) == key
+            assert hdict.historical(key, -1) == value

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "llm",
   "networkx",
   "tiktoken",
+  "bidict",
 ]
 description = "DAGs for LLM interactions"
 classifiers = [


### PR DESCRIPTION
By default, when we do inverse mapping on values, `list`, `dict`, and `set` values are not hashable and throw an error.

This PR casts them first to a string, both in the getter and setter methods.

I don't think we need to worry about collisions, since I think effectively lists `[1,2,3] == [1,2,3]` even if they are different instantiations. I can't think of a use case where you'd have identical lists of different IDs that you'd want to be keyed differently.