### PR TITLE
Handle non-typed and mixed type inputs

### DIFF
--- a/packages/python/diagraph/utils/annotations.py
+++ b/packages/python/diagraph/utils/annotations.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Annotated, Any, Callable
 from ..classes.types import Fn
 
@@ -9,6 +10,7 @@ def is_annotated(val: Any):
 def get_annotations(node: Callable):
     # inspect.get_annotations() does not work with MagicMock (mocker.stub())
     # for key, val in inspect.get_annotations(node).items():
+    print(inspect.get_annotations(node))
     for key, val in node.__annotations__.items():
         if key != "return" and is_annotated(val):
             yield key, val

--- a/packages/python/diagraph/utils/build_graph_test.py
+++ b/packages/python/diagraph/utils/build_graph_test.py
@@ -15,7 +15,10 @@ def test_returns_a_single_node_graph_and_ignores_return_key():
 
 
 def test_works_with_a_stub(mocker):
-    stub = mocker.stub()
+    mock_instance = mocker.Mock()
+
+    def stub():
+        return mock_instance()
 
     assert build_graph(stub) == {stub: set()}
 


### PR DESCRIPTION
The previous implementation was a bit too insistent upon inspecting input arguments of specific types (strings, to be exact).

This refactors it to be less strict. Now, if annotated dependencies are found, they are hydrated; if not, arguments are provided in order they are passed.

Probably will need to revisit this further to support potential `kwargs` to a run function.