### PR TITLE
Store prompts when generated

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -130,10 +130,13 @@ class Diagraph:
                         }
                         ran.add(node)
                         if is_decorated(node.fn):
-                            generated_prompt, result = self.__run_node__(
-                                node, *input_args, **kwargs
-                            )
-                            node.prompt = generated_prompt
+                            encountered_prompt = False
+                            for r in self.__run_node__(node, *input_args, **kwargs):
+                                if encountered_prompt is False:
+                                    encountered_prompt = True
+                                    node.prompt = r
+                                else:
+                                    result = r
                         else:
                             result = self.__run_node__(node, *input_args, **kwargs)
                         run["nodes"][node.key] = {

--- a/packages/python/diagraph/decorators/prompt.py
+++ b/packages/python/diagraph/decorators/prompt.py
@@ -26,9 +26,10 @@ def prompt(_func=None, *, log=None, llm=None, error=None, return_type=None):
                     diagraph_log(event, chunk, wrapper_fn)
 
             generated_prompt = func(*args, **kwargs)
+            yield generated_prompt
 
             try:
-                return generated_prompt, llm.run(generated_prompt, log=_log)
+                yield llm.run(generated_prompt, log=_log)
             except Exception as e:
                 # TODO: Should both error functions be called? Or should one supersede the other?
                 if error:


### PR DESCRIPTION
As soon as a function returns a prompt, store it. Don't wait for the function to execute.

If we wait, a function could potentially fail and we lose the generated prompt. If we store it as soon as it's created we ensure access to it.