### PR TITLE
Fix bug with historical bidict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 build
 *.egg-info
 scratch
+node_modules
+.wireit

--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -254,9 +254,7 @@ class Diagraph:
             results = [node.result for node in self.terminal_nodes]
         else:
             latest_depth = latest_run.get("active_depth")
-            # print(latest_depth)
             for node_key, node_run_value in latest_run.get("nodes").items():
-                # print("node", node_key, node_run_value)
                 if node_run_value.get("depth") == latest_depth:
                     if node_run_value.get("executed") is None:
                         results.append(None)
@@ -282,14 +280,12 @@ class Diagraph:
         args = []
         arg_index = 0
         fn = self.fns[node.key]
-        # print("input args", input_args)
         # If a user has explicitly specified a dependency via an annotation, we hydrate
         # it below.
         # If an argument is _not_ specified as a dependency, pull off the next input arg
         # in order
         encountered_star = False
         for parameter in inspect.signature(fn).parameters.values():
-            # print("parameter", parameter.default)
             # Depends can be passed as Annotated[str, Depends]
             if is_annotated(parameter.annotation):
                 dep: Fn = get_dependency(parameter.annotation)
@@ -317,9 +313,6 @@ class Diagraph:
                     raise Exception(
                         "Found arguments defined after * args. Ensure *args and **kwargs come at the end of the function parameter definitions."
                     )
-                # else:
-                print(arg_index, input_args)
-
                 if arg_index > len(input_args) - 1:
                     raise Exception(
                         f'No argument provided for "{parameter.name}" in function {fn.__name__}. This indicates you forgot to call ".run()" with sufficient arguments.'
@@ -329,7 +322,6 @@ class Diagraph:
             else:
                 encountered_star = True
 
-                # print(arg_index, len(input_args))
                 if arg_index < len(input_args):
                     for arg in input_args[arg_index:]:
                         args.append(arg)

--- a/packages/python/diagraph/classes/historical_bidict.py
+++ b/packages/python/diagraph/classes/historical_bidict.py
@@ -6,7 +6,14 @@ Value = TypeVar("Value")
 
 
 def is_not_hashable(value):
-    return isinstance(value, (list, dict, set))
+    if isinstance(value, (list, dict, set)):
+        return True
+
+    if isinstance(value, tuple):
+        for val in value:
+            if is_not_hashable(val):
+                return True
+    return False
 
 
 class HistoricalBidict(Generic[Key, Value]):
@@ -22,9 +29,9 @@ class HistoricalBidict(Generic[Key, Value]):
 
     def __setitem__(self, key: Key, value: Value):
         self.keys[key] = self.keys.get(key, []) + [value]
-        if is_not_hashable(value):
-            self.values_to_keys[str(value)] = key
-        else:
+        if is_not_hashable(value) is False:
+            #     self.values_to_keys[str(value)] = key
+            # else:
             self.values_to_keys[value] = key
 
     def __getitem__(self, key: Key):
@@ -37,7 +44,10 @@ class HistoricalBidict(Generic[Key, Value]):
 
     def inverse(self, value: Value):
         if is_not_hashable(value):
-            return self.values_to_keys[str(value)]
+            raise Exception(
+                f"Value {value} is not hashable and cannot be used as an inverse key"
+            )
+            # return self.values_to_keys[str(value)]
         return self.values_to_keys[value]
 
     def historical(self, key: Key, index: int):


### PR DESCRIPTION
Fixes a bug where non-hashable values could not be used as inverse keys. If a non-hashable value is provided, simply ignore it (but raise an exception if a user tries to inverse index with it).

Also remove some print statements.