### PR TITLE
Rename DiagraphLayer to DiagraphNodeGroup

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -10,7 +10,7 @@ from ..llm.llm import LLM
 from ..decorators.is_decorated import is_decorated
 from asyncio import run, gather
 
-from .diagraph_layer import DiagraphLayer
+from .diagraph_node_group import DiagraphNodeGroup
 
 from ..decorators.prompt import UserHandledException, set_default_llm
 
@@ -126,14 +126,14 @@ class Diagraph:
     #     return str(self.__graph__)
 
     @overload
-    def __getitem__(self, key: int) -> DiagraphLayer:
+    def __getitem__(self, key: int) -> DiagraphNodeGroup:
         ...
 
     @overload
     def __getitem__(self, key: Fn) -> DiagraphNode:
         ...
 
-    def __getitem__(self, key: Fn | int) -> DiagraphNode | DiagraphLayer:
+    def __getitem__(self, key: Fn | int) -> DiagraphNode | DiagraphNodeGroup:
         """
         Retrieve a DiagraphNode or DiagraphLayer associated with a function or depth key.
 
@@ -146,7 +146,7 @@ class Diagraph:
         node_keys = self.__graph__[key]
         if isinstance(node_keys, list):
             if isinstance(key, int):
-                return DiagraphLayer(self, key, *node_keys)
+                return DiagraphNodeGroup(self, key, *node_keys)
             raise Exception(
                 f"Unexpected key when trying to build a diagraph layer: {key}"
             )
@@ -188,7 +188,7 @@ class Diagraph:
         }
         self.runs.append(run)
         nodes = self[node_key]  # nodes is a diagraph node
-        if not isinstance(nodes, DiagraphLayer):
+        if not isinstance(nodes, DiagraphNodeGroup):
             nodes = (nodes,)
 
         run["starting_nodes"] = nodes

--- a/packages/python/diagraph/classes/diagraph_node_group.py
+++ b/packages/python/diagraph/classes/diagraph_node_group.py
@@ -5,11 +5,11 @@ from .diagraph_node import DiagraphNode
 from .graph import Key
 
 
-class DiagraphLayer:
+class DiagraphNodeGroup:
     """A layer of DiagraphNodes representing a set of related nodes in a Diagraph."""
 
     diagraph: Any
-    nodes: tuple[DiagraphNode]
+    nodes: tuple[DiagraphNode, ...]
     key: int
 
     def __init__(self, diagraph: Any, key: int, *node_keys: Key):

--- a/packages/python/diagraph/classes/diagraph_node_group_test.py
+++ b/packages/python/diagraph/classes/diagraph_node_group_test.py
@@ -1,12 +1,12 @@
 from .diagraph import Diagraph
 
 from ..utils.depends import Depends
-from .diagraph_layer import DiagraphLayer
+from .diagraph_node_group import DiagraphNodeGroup
 
 
-def describe_diagraph_layer():
+def describe_diagraph_node_group():
     def test_it_instantiates():
-        DiagraphLayer(Diagraph(), 0)
+        DiagraphNodeGroup(Diagraph(), 0)
 
     def test_it_iterates_through_nodes():
         def d0():

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -7,7 +7,7 @@ import pytest
 from ..llm.openai_llm import OpenAI
 
 
-from .diagraph_layer import DiagraphLayer
+from .diagraph_node_group import DiagraphNodeGroup
 from .diagraph import Diagraph
 from .diagraph_node import DiagraphNode
 from ..utils.depends import Depends
@@ -50,9 +50,9 @@ def describe_indexing():
 
         diagraph = Diagraph(baz)
 
-        assert isinstance(diagraph[0], DiagraphLayer) and diagraph[0][0].fn == foo
-        assert isinstance(diagraph[2], DiagraphLayer) and diagraph[2][0].fn == baz
-        assert isinstance(diagraph[-1], DiagraphLayer) and diagraph[-1][0].fn == baz
+        assert isinstance(diagraph[0], DiagraphNodeGroup) and diagraph[0][0].fn == foo
+        assert isinstance(diagraph[2], DiagraphNodeGroup) and diagraph[2][0].fn == baz
+        assert isinstance(diagraph[-1], DiagraphNodeGroup) and diagraph[-1][0].fn == baz
 
     def test_it_gets_back_a_tuple_for_parallels():
         def l0():
@@ -71,7 +71,7 @@ def describe_indexing():
 
         def check_tuple(key):
             nodes = diagraph[key]
-            assert isinstance(nodes, DiagraphLayer) and len(nodes) == 2
+            assert isinstance(nodes, DiagraphNodeGroup) and len(nodes) == 2
             return set([n.fn for n in nodes])
 
         assert check_tuple(1) == {l1_l, l1_r}
@@ -134,7 +134,7 @@ def describe_indexing():
 
         def get_layer(diagraph, key):
             layer = diagraph[key]
-            assert isinstance(layer, DiagraphLayer)
+            assert isinstance(layer, DiagraphNodeGroup)
             return layer
 
         for node in [l0, l1_l, l1_r, l2_l, l2_r, l3_l, l4]:
@@ -183,7 +183,7 @@ def describe_indexing():
 
         def get_layer(diagraph, key):
             layer = diagraph[key]
-            assert isinstance(layer, DiagraphLayer)
+            assert isinstance(layer, DiagraphNodeGroup)
             return layer
 
         for node in [l0, l1_l, l1_r, l2_l, l3_l, l2_r]:
@@ -227,7 +227,7 @@ def describe_indexing():
 
         def get_layer(diagraph, key):
             layer = diagraph[key]
-            assert isinstance(layer, DiagraphLayer)
+            assert isinstance(layer, DiagraphNodeGroup)
             return layer
 
         for node in [l0_l, l0_r, l1_l, l1_r, l2]:
@@ -268,7 +268,7 @@ def describe_indexing():
 
         def get_layer(diagraph, key):
             layer = diagraph[key]
-            assert isinstance(layer, DiagraphLayer)
+            assert isinstance(layer, DiagraphNodeGroup)
             return layer
 
         for node in [d0, d1a, d1b]:
@@ -321,7 +321,7 @@ def describe_indexing():
 
         def get_layer(diagraph, key):
             layer = diagraph[key]
-            assert isinstance(layer, DiagraphLayer)
+            assert isinstance(layer, DiagraphNodeGroup)
             return layer
 
         for node in [d0a, d0b, d1]:
@@ -374,7 +374,7 @@ def describe_indexing():
 
         def get_layer(diagraph, key):
             layer = diagraph[key]
-            assert isinstance(layer, DiagraphLayer)
+            assert isinstance(layer, DiagraphNodeGroup)
             return layer
 
         for node in [d0a, d0b, d1a, d1b, d2]:

--- a/packages/python/diagraph/utils/validate_node_ancestors.py
+++ b/packages/python/diagraph/utils/validate_node_ancestors.py
@@ -1,8 +1,8 @@
 from ..classes.diagraph_node import DiagraphNode
-from ..classes.diagraph_layer import DiagraphLayer
+from ..classes.diagraph_node_group import DiagraphNodeGroup
 
 
-def validate_node_ancestors(layer: tuple[DiagraphNode] | DiagraphLayer):
+def validate_node_ancestors(layer: tuple[DiagraphNode] | DiagraphNodeGroup):
     for node in layer:
         for ancestor in node.ancestors:
             if ancestor.result is None:


### PR DESCRIPTION
This will better support arbitrary groupings of nodes, instead of requiring that nodes be collections of same-layer nodes