### PR TITLE
Enable rerun functionality

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -286,7 +286,7 @@ class Diagraph:
 
             def rerun(**kwargs: dict[Any, Any]):
                 self.__execute_node__(
-                    node, input_args, input_kwargs, rerun_kwargs=kwargs
+                    node, input_args, input_kwargs, rerun_kwargs=kwargs,
                 )
                 # TODO: Refactor or remove this
                 return node.result
@@ -310,7 +310,7 @@ class Diagraph:
             node.error = e
 
     def __run_node__(
-        self, node: DiagraphNode, input_args: tuple[Any], kwargs: None | dict[Any, Any]
+        self, node: DiagraphNode, input_args: tuple[Any], kwargs: None | dict[Any, Any],
     ) -> Result:
         """
         Execute a single node in the Diagraph.

--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -169,7 +169,10 @@ class Diagraph:
         return self
 
     def __run_from__(
-        self, group: DiagraphNodeGroup | DiagraphNode, *input_args, **kwargs,
+        self,
+        group: DiagraphNodeGroup | DiagraphNode,
+        *input_args,
+        **kwargs,
     ) -> Diagraph:
         """
         Run the Diagraph from a specific node.
@@ -203,7 +206,9 @@ class Diagraph:
                 with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
                     executor.map(
                         lambda key: self.__execute_node__(
-                            self[key], *input_args, **kwargs,
+                            self[key],
+                            input_args,
+                            kwargs,
                         ),
                         keys,
                     )
@@ -254,9 +259,22 @@ class Diagraph:
             return tuple(errors)
         return None
 
-    def __execute_node__(self, node: DiagraphNode, *input_args, **kwargs) -> None:
+    def __execute_node__(
+        self,
+        node: DiagraphNode,
+        input_args: tuple[Any],
+        input_kwargs: dict[Any, Any],
+        rerun_kwargs: dict[Any, Any] = {},
+    ) -> None:
+        # if (
+        #     input_kwargs is not None
+        #     and "times" in input_kwargs
+        #     and input_kwargs.get("times") == 5
+        # ):
+        #     raise Exception("STOP IT NOT")
         try:
-            node.result = self.__run_node__(node, *input_args, **kwargs)
+            # print("incoming", input_args, input_kwargs)
+            node.result = self.__run_node__(node, input_args, input_kwargs)
         except Exception as e:
             # TODO: Make this a custom error
             if "Error found for " in str(e):
@@ -265,10 +283,25 @@ class Diagraph:
                 return
             fn = self.fns[node.key]
             fn_error_handler = getattr(fn, "__function_error__", None)
-            for err_handler in [fn_error_handler, self.error_handler, global_error_fn]:
+
+            def rerun(**kwargs: dict[Any, Any]):
+                self.__execute_node__(
+                    node, input_args, input_kwargs, rerun_kwargs=kwargs
+                )
+                # TODO: Refactor or remove this
+                return node.result
+
+            for err_handler, accepts_fn in [
+                (fn_error_handler, False),
+                (self.error_handler, True),
+                (global_error_fn, True),
+            ]:
                 if err_handler:
+                    err_handler_args = [e, rerun]
+                    if accepts_fn:
+                        err_handler_args.append(fn)
                     try:
-                        result = err_handler(e, lambda: None, fn)
+                        result = err_handler(*err_handler_args, **rerun_kwargs)
                         node.result = result
                     except Exception as raised_exception:
                         node.error = raised_exception
@@ -276,13 +309,11 @@ class Diagraph:
             # if no error functions are defined, save the error
             node.error = e
 
-    def __run_node__(self, node: DiagraphNode, *input_args, **kwargs) -> Result:
+    def __run_node__(
+        self, node: DiagraphNode, input_args: tuple[Any], kwargs: None | dict[Any, Any]
+    ) -> Result:
         """
         Execute a single node in the Diagraph.
-
-        Args:
-            node (Fn): The function node to execute.
-            *input_args: Input arguments to be passed to the node.
 
         Returns:
             Any: The result of executing the node.

--- a/packages/python/diagraph/classes/types.py
+++ b/packages/python/diagraph/classes/types.py
@@ -13,4 +13,5 @@ Rerunner = Callable[..., None]
 LogHandler = Callable[[str, str, Fn], None]
 FunctionLogHandler = Callable[[LogEventName, str | None], None]
 ErrorHandler = Callable[[Exception, Rerunner, Fn], None]
+# Todo: Support arbitrary args and kwargs.
 FunctionErrorHandler = Callable[[Exception, Rerunner], None]

--- a/packages/python/diagraph/classes/types.py
+++ b/packages/python/diagraph/classes/types.py
@@ -13,5 +13,5 @@ Rerunner = Callable[..., None]
 LogHandler = Callable[[str, str, Fn], None]
 FunctionLogHandler = Callable[[LogEventName, str | None], None]
 ErrorHandler = Callable[[Exception, Rerunner, Fn], None]
-# Todo: Support arbitrary args and kwargs.
+# TODO: Support arbitrary args and kwargs.
 FunctionErrorHandler = Callable[[Exception, Rerunner], None]

--- a/packages/python/diagraph/decorators/prompt_test.py
+++ b/packages/python/diagraph/decorators/prompt_test.py
@@ -1,4 +1,3 @@
-import pytest
 from ..classes.diagraph import Diagraph
 from ..llm.llm import LLM
 from ..utils.depends import Depends
@@ -713,5 +712,5 @@ def describe_errors():
 
         dg = Diagraph(fn).run()
         function_handle_errors.assert_any_call(0)
-        assert dg.result == None
+        assert dg.result is None
         assert str(dg[fn].error) == "stop"

--- a/packages/python/diagraph/llm/openai_llm.py
+++ b/packages/python/diagraph/llm/openai_llm.py
@@ -58,7 +58,8 @@ class OpenAI(LLM):
         messages = cast_to_input(prompt)
 
         response = ""
-        del kwargs["stream"]
+        if "stream" in kwargs:
+            del kwargs["stream"]
         kwargs = {
             **self.kwargs,
             **kwargs,
@@ -93,7 +94,8 @@ class OpenAI(LLM):
         messages = cast_to_input(prompt)
 
         response = ""
-        del kwargs["stream"]
+        if "stream" in kwargs:
+            del kwargs["stream"]
         kwargs = {
             **self.kwargs,
             **kwargs,


### PR DESCRIPTION
Add support for rerunning a particular node upon a caught exception.

Also support the ability to pass arbitrary kwargs to the rerun function, in order to track things like number of times rerun