### PR TITLE
Raise error if error is encountered

### DIFF
--- a/packages/python/.gitignore
+++ b/packages/python/.gitignore
@@ -8,3 +8,4 @@ dist
 env
 .python-version
 diagraph/assets/*
+dev

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -1640,10 +1640,12 @@ def describe_inputs():
             args = "|".join(args)
             return f"d1:{args}"
 
-        # with pytest.raises(Exception):
-        dg = Diagraph(d1).run("foo", "bar", "baz")
-        assert dg.result is None
-        assert "Found arguments defined after * args" in str(dg[d1].error)
+        with pytest.raises(
+            Exception, match="Errors encountered. Call .error to see errors.",
+        ):
+            dg = Diagraph(d1).run("foo", "bar", "baz")
+            assert dg.result is None
+            assert "Found arguments defined after * args" in str(dg[d1].error)
 
         def d2(foo, *args):
             args = "|".join(args)
@@ -1680,9 +1682,12 @@ def describe_inputs():
                 def fn():
                     return None
 
-                dg = Diagraph(fn).run()
-                assert dg.result is None
-                assert "unsupported operand type(s) for +" in str(dg[fn].error)
+                with pytest.raises(
+                    Exception, match="Errors encountered. Call .error to see errors.",
+                ):
+                    dg = Diagraph(fn).run()
+                    assert dg.result is None
+                    assert "unsupported operand type(s) for +" in str(dg[fn].error)
 
         def test_it_does_a_real_world_example_with_prompt_fn():
             def fake_run(self, string, stream=None, **kwargs):

--- a/packages/python/diagraph/classes/graph.py
+++ b/packages/python/diagraph/classes/graph.py
@@ -19,7 +19,8 @@ class Graph(Generic[K]):
         self.graph_def = {key: list(val) for key, val in graph_def.items()}
         self.__key_to_int__ = {}
         self.__G__ = nx.convert_node_labels_to_integers(
-            nx.DiGraph(self.graph_def), label_attribute="ref",
+            nx.DiGraph(self.graph_def),
+            label_attribute="ref",
         )
 
         for int_representation in self.__G__.nodes():
@@ -55,6 +56,10 @@ class Graph(Generic[K]):
         node = self.get_int_key_for_node(int_key)
         int_representations = [i for _, i in list(self.__G__.out_edges(node))]
         return [self.get_node_for_int_key(i) for i in int_representations]
+
+    @property
+    def nodes(self) -> list[K]:
+        return [self.get_node_for_int_key(i) for i in self.__G__.nodes()]
 
     @property
     def root_nodes(self) -> list[K]:

--- a/packages/python/diagraph/llm/openai_llm.py
+++ b/packages/python/diagraph/llm/openai_llm.py
@@ -24,15 +24,17 @@ class OpenAI(LLM):
     __aclient__: AsyncOpenAI | None = None
     __client__: SyncOpenAI | None = None
     kwargs: dict[Any, Any]
+    api_key: None | str
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, api_key=None, **kwargs) -> None:
+        self.api_key = api_key
         self.kwargs = kwargs
 
     @property
     def aclient(self) -> AsyncOpenAI:
         aclient = self.__aclient__
         if aclient is None:
-            aclient = AsyncOpenAI()
+            aclient = AsyncOpenAI(api_key=self.api_key)
             self.__aclient__ = aclient
 
         return aclient
@@ -41,7 +43,7 @@ class OpenAI(LLM):
     def client(self) -> SyncOpenAI:
         client = self.__client__
         if client is None:
-            client = SyncOpenAI()
+            client = SyncOpenAI(api_key=self.api_key)
             self.__client__ = client
 
         return client

--- a/packages/python/diagraph/llm/openai_llm_test.py
+++ b/packages/python/diagraph/llm/openai_llm_test.py
@@ -65,12 +65,12 @@ class Chat:
 
 
 class MockASyncOpenAI:
-    def __init__(self, times=1):
+    def __init__(self, api_key=None, times=1):
         self.chat = Chat(times=times, is_async=True)
 
 
 class MockSyncOpenAI:
-    def __init__(self, times=1):
+    def __init__(self, api_key=None, times=1):
         self.chat = Chat(times=times, is_async=False)
 
 

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diagraph"
-version = "0.3.1"
+version = "0.3.2"
 # Notes
 authors = [{ name = "Kevin Scott", email = "kevin@diagraph.dev" }]
 readme = "README.md"
@@ -89,6 +89,7 @@ unfixable = []
   "ARG002",
   "A002",
   "A001",
+  "PT012",
 ]
 
 


### PR DESCRIPTION
If we encounter an error, `result` comes back as None, which is extremely unhelpful.

I think it'd be better to raise an explicit Exception, _only_ once the Diagraph has completed its run, to indicate to the user that an error occurred.