### PR TITLE
Refactor graph execution

### DIFF
--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -39,9 +39,10 @@ class DiagraphNode:
             str: The string representation of the node.
         """
         if isinstance(self.key, str):
-            return self.key
+            return f"DiagraphNode[{self.key!s}]"
 
-        return self.key.__name__
+        # return self.key.__name__
+        return f"DiagraphNode[{self.key!s}]"
 
     @property
     def fn(self) -> Fn:
@@ -80,7 +81,7 @@ class DiagraphNode:
         Returns:
             str: The string representation of the node.
         """
-        return str(self.key)
+        return f"Key: [{self.key!s}]"
 
     @property
     def __is_decorated__(self) -> bool:
@@ -105,6 +106,13 @@ class DiagraphNode:
 
         self.diagraph.__run_from__(self, *input_args, **kwargs)
         return self.diagraph
+
+    @property
+    def __ready__(self) -> bool:
+        for ancestor in self.ancestors:
+            if ancestor.result is None:
+                return False
+        return True
 
     @property
     def result(self) -> Result:

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -424,6 +424,7 @@ def describe_run():
         mock_instance = mocker.Mock()
 
         def d0():
+            print("d0")
             return mock_instance()
 
         diagraph = Diagraph(d0)
@@ -1641,7 +1642,8 @@ def describe_inputs():
             return f"d1:{args}"
 
         with pytest.raises(
-            Exception, match="Errors encountered. Call .error to see errors.",
+            Exception,
+            match="Errors encountered. Call .error to see errors.",
         ):
             dg = Diagraph(d1).run("foo", "bar", "baz")
             assert dg.result is None
@@ -1683,7 +1685,8 @@ def describe_inputs():
                     return None
 
                 with pytest.raises(
-                    Exception, match="Errors encountered. Call .error to see errors.",
+                    Exception,
+                    match="Errors encountered. Call .error to see errors.",
                 ):
                     dg = Diagraph(fn).run()
                     assert dg.result is None

--- a/packages/python/diagraph/classes/graph_executor.py
+++ b/packages/python/diagraph/classes/graph_executor.py
@@ -1,0 +1,34 @@
+import concurrent.futures
+from typing import Any
+
+from .diagraph_node import DiagraphNode
+from .diagraph_node_group import DiagraphNodeGroup
+from .types import Fn
+
+
+class GraphExecutor:
+    executor: concurrent.futures.ThreadPoolExecutor
+    seen_keys: set[Fn]
+    fn: Any
+
+    def __init__(
+        self,
+        starting_nodes: DiagraphNodeGroup,
+        fn: Any,
+        max_workers: int,
+    ):
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        self.seen_keys = set()
+        self.fn = fn
+        for node in starting_nodes.nodes:
+            self.schedule(node)
+        self.executor.shutdown(wait=True)
+
+    def schedule(self, node: DiagraphNode) -> None:
+        if node.key not in self.seen_keys:
+            self.seen_keys.add(node.key)
+            future = self.executor.submit(self.fn, node)
+            concurrent.futures.wait([future])
+            for child in node.children:
+                if child.__ready__:
+                    self.schedule(child)

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diagraph"
-version = "0.3.3"
+version = "0.4.0"
 # Notes
 authors = [{ name = "Kevin Scott", email = "kevin@diagraph.dev" }]
 readme = "README.md"


### PR DESCRIPTION
This refactors the way Diagraph approaches graph execution.

Instead of getting groups of nodes to operate on, and concurrently executing all nodes in a group (and waiting for that node group to complete), it now takes a list of pointers to the starting nodes of a graph and steps those pointers through the graph, executing any nodes it fines as soon as they are ready to execute.

This slightly deprecates the concept of "layers" in a diagraph, but should speed up execution.