### PR TITLE
Change str representation for nodes

### DIFF
--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -81,7 +81,7 @@ class DiagraphNode:
         Returns:
             str: The string representation of the node.
         """
-        return f"Key: [{self.key!s}]"
+        return f"Node[{self.key!s}]"
 
     @property
     def __is_decorated__(self) -> bool:

--- a/packages/python/diagraph/classes/diagraph_node_group.py
+++ b/packages/python/diagraph/classes/diagraph_node_group.py
@@ -49,7 +49,7 @@ class DiagraphNodeGroup:
         Returns:
             str: A string representation of the layer.
         """
-        return f"DiagraphNodeGroup({[str(n) for n in self.nodes]})"
+        return f"({[str(n) for n in self.nodes]})"
 
     def __getitem__(self, key: Fn | int) -> DiagraphNode:
         """


### PR DESCRIPTION
Nodes should read:

`Node[function_name]`

And groups should read:

`(Node[fn],Node[foo],Node[bar])`