### PR TITLE
Move error checking into __run_from__

### DIFF
--- a/packages/python/diagraph/classes/diagraph.py
+++ b/packages/python/diagraph/classes/diagraph.py
@@ -156,17 +156,6 @@ class Diagraph:
         root_nodes: list[Fn] = self.__graph__.root_nodes
         group = DiagraphNodeGroup(self, *root_nodes)
         self.__run_from__(group, *input_args, **kwargs)
-        errors_encountered = self.error
-        if errors_encountered is not None:
-            if isinstance(errors_encountered, Exception):
-                raise Exception(
-                    f"Errors encountered. {errors_encountered} Call .error to see errors",
-                )
-            errors_encountered = [e for e in errors_encountered if e is not None]
-            if len(errors_encountered) > 0:
-                raise Exception(
-                    f"Errors encountered. {errors_encountered} Call .error to see errors",
-                )
         return self
 
     def __run_from__(
@@ -208,6 +197,17 @@ class Diagraph:
             global_error_fn=global_error_fn,
         )
         run["complete"] = True
+        errors_encountered = self.error
+        if errors_encountered is not None:
+            if isinstance(errors_encountered, Exception):
+                raise Exception(
+                    f"Errors encountered. {errors_encountered} Call .error to see errors",
+                )
+            errors_encountered = [e for e in errors_encountered if e is not None]
+            if len(errors_encountered) > 0:
+                raise Exception(
+                    f"Errors encountered. {errors_encountered} Call .error to see errors",
+                )
 
         return self
 
@@ -263,7 +263,6 @@ class Diagraph:
     @property
     def nodes(self):
         return [DiagraphNode(self, node) for node in self.__graph__.nodes]
-
 
     def __setitem__(self, node_key: Fn, fn: Fn) -> None:
         """


### PR DESCRIPTION
Fixes bug where errors would not be explicitly thrown if run from a subnode.