### PR TITLE
Refactor string keys

### DIFF
--- a/packages/python/diagraph/classes/diagraph_node.py
+++ b/packages/python/diagraph/classes/diagraph_node.py
@@ -7,7 +7,7 @@ import tiktoken
 
 from ..decorators.is_decorated import is_decorated
 from .graph import Graph
-from .types import Fn, Result
+from .types import Fn, KeyIdentifier, Result
 
 if TYPE_CHECKING:
     from .diagraph import Diagraph
@@ -18,9 +18,9 @@ class DiagraphNode:
 
     diagraph: Diagraph
     __graph__: Graph
-    key: Fn
+    key: KeyIdentifier
 
-    def __init__(self, diagraph: Diagraph, key: Fn) -> None:
+    def __init__(self, diagraph: Diagraph, key: KeyIdentifier) -> None:
         """
         Initialize a DiagraphNode.
 
@@ -28,11 +28,11 @@ class DiagraphNode:
             diagraph (Diagraph): The Diagraph instance that contains this node.
             key (Key): The key associated with the node.
         """
-        if not isinstance(key, Callable):
-            raise Exception(f'Key "{key}" is not a callable function')
+        if not isinstance(key, Callable) and not isinstance(key, str):
+            raise Exception(f'Key "{key}" is not a callable function or string')
         self.diagraph = diagraph
         self.__graph__ = diagraph.__graph__
-        self.key = key
+        self.key = diagraph.get_key_for_fn(key)
 
     def __str__(self) -> str:
         """
@@ -52,7 +52,10 @@ class DiagraphNode:
         Returns:
             Fn: The function associated with the node.
         """
-        return self.diagraph.fns[self.key]
+        fn = self.diagraph.fns.get(self.key)
+        if fn is None:
+            raise Exception(f'Function "{self.key}" not found in Diagraph')
+        return fn
 
     @property
     def ancestors(self) -> list[DiagraphNode]:

--- a/packages/python/diagraph/classes/diagraph_node_group.py
+++ b/packages/python/diagraph/classes/diagraph_node_group.py
@@ -4,7 +4,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 from .diagraph_node import DiagraphNode
-from .types import Fn, Result
+from .types import Fn, KeyIdentifier, Result
 
 if TYPE_CHECKING:
     from .diagraph import Diagraph
@@ -16,7 +16,9 @@ class DiagraphNodeGroup:
     diagraph: Diagraph
     nodes: tuple[DiagraphNode, ...]
 
-    def __init__(self, diagraph: Diagraph, *node_keys: Fn | DiagraphNode) -> None:
+    def __init__(
+        self, diagraph: Diagraph, *node_keys: KeyIdentifier | DiagraphNode,
+    ) -> None:
         """
         Initialize a DiagraphNodeGroup.
 

--- a/packages/python/diagraph/classes/diagraph_state/diagraph_state.py
+++ b/packages/python/diagraph/classes/diagraph_state/diagraph_state.py
@@ -39,7 +39,8 @@ class DiagraphState:
         # validate_key(key[0])
         record = self.__internal_state__.get(key, None)
         if record is None:
-            raise Exception(f"No record for {get_key(key)}")
+            state = {key: str(val) for key, val in self.__internal_state__.items()}
+            raise Exception(f"No record for {get_key(key)}, {state}")
         value = record[timestamp]
         if isinstance(value, DiagraphStateValue):
             return value.value
@@ -63,6 +64,7 @@ def get_name(f: str | Callable) -> str:
     if isinstance(f, str):
         return f
     return f.__name__
+
 
 # def validate_key(key: str):
 #     if key not in ['prompt', 'result', 'error']:

--- a/packages/python/diagraph/classes/diagraph_test.py
+++ b/packages/python/diagraph/classes/diagraph_test.py
@@ -23,16 +23,74 @@ def describe_instantiation():
         Diagraph(foo)
 
 
-# def describe_nodes():
-#     def test_it_gets_back_a_node_wrapper_for_a_function():
-#         def foo():
-#             return "foo"
+def describe_nodes():
+    def test_it_gets_back_a_node_wrapper_for_a_function():
+        def foo():
+            return "foo"
 
-#         diagraph = Diagraph(foo, use_string_keys=True)
+        dg = Diagraph(foo, use_string_keys=False)
 
-#         node = diagraph["foo"]
-#         assert isinstance(node, DiagraphNode)
-#         assert node.fn == foo
+        node = dg[foo]
+        assert isinstance(node, DiagraphNode)
+        assert node.fn == foo
+
+    def describe_string_keys():
+
+        def test_it_gets_back_a_node_wrapper_for_a_function_using_string_keys():
+            def foo():
+                return "foo"
+
+            dg = Diagraph(foo, use_string_keys=True, node_dict={"foo": foo})
+
+            node = dg["foo"]
+            assert isinstance(node, DiagraphNode)
+            assert node.fn == foo
+
+        def test_it_can_run_from_a_string_key():
+            def foo():
+                return "foo"
+
+            dg = Diagraph(foo, use_string_keys=True, node_dict={"foo": foo})
+
+            dg.run("foo")
+            assert dg.result == "foo"
+
+        # def test_nodes_can_specify_dependencies_as_functions_alongside_string_keys():
+        #     def foo():
+        #         return "foo"
+
+        #     def bar(foo=Depends(foo)):
+        #         return f"bar: {foo}"
+
+        #     def baz(bar=Depends(bar)):
+        #         return f"baz: {bar}"
+
+        #     dg = Diagraph(baz, use_string_keys=True, node_dict={'foo': foo, 'bar':
+        #         bar, 'baz': baz})
+        #     dg["foo"].result = "foo1"
+
+        #   dg["bar"].run()
+        #     assert dg.result == "baz: bar: foo1"
+
+        def test_nodes_can_specify_dependencies_as_strings_alongside_string_keys():
+            def foo():
+                return "foo"
+
+            def bar(foo=Depends("foo")):
+                return f"bar: {foo}"
+
+            def baz(bar=Depends("bar")):
+                return f"baz: {bar}"
+
+            dg = Diagraph(
+                baz,
+                use_string_keys=True,
+                node_dict={"foo": foo, "bar": bar, "baz": baz},
+            )
+            dg["foo"].result = "foo1"
+
+            dg["bar"].run()
+            assert dg.result == "baz: bar: foo1"
 
 
 def describe_indexing():
@@ -1969,14 +2027,14 @@ def describe_replay():
 
         diagraph[d0].result = "newresult"
 
-        with pytest.raises(Exception, match='unset'):
+        with pytest.raises(Exception, match="unset"):
             diagraph[d1a].result
-        with pytest.raises(Exception, match='unset'):
+        with pytest.raises(Exception, match="unset"):
             diagraph[d1b].result
-        with pytest.raises(Exception, match='unset'):
+        with pytest.raises(Exception, match="unset"):
             diagraph[d2].result
 
-        diagraph[d1b].result = 'd1b'
+        diagraph[d1b].result = "d1b"
 
         diagraph[d1a].run("bar")
 

--- a/packages/python/diagraph/classes/graph_executor.py
+++ b/packages/python/diagraph/classes/graph_executor.py
@@ -1,23 +1,26 @@
 import concurrent.futures
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..decorators.is_decorated import is_decorated
 from ..utils.build_parameters import build_parameters
-
-# from .diagraph import Diagraph
 from .diagraph_node import DiagraphNode
 from .diagraph_node_group import DiagraphNodeGroup
-from .types import ErrorHandler, Fn, Result
+from .types import ErrorHandler, KeyIdentifier, Result
+
+if TYPE_CHECKING:
+    pass
 
 
 class GraphExecutor:
+    # diagraph: Diagraph
     diagraph: Any
     executor: concurrent.futures.ThreadPoolExecutor
     global_error_fn: ErrorHandler | None = None
-    seen_keys: set[Fn]
+    seen_keys: set[KeyIdentifier]
 
     def __init__(
         self,
+        # diagraph: Diagraph,
         diagraph: Any,
         starting_nodes: DiagraphNodeGroup,
         input_args,
@@ -117,7 +120,12 @@ class GraphExecutor:
         # in order
         fn = self.diagraph.fns[node.key]
 
-        args, kwargs = build_parameters(self.diagraph, fn, provided_args, provided_kwargs)
+        args, kwargs = build_parameters(
+            self.diagraph,
+            fn,
+            provided_args,
+            provided_kwargs,
+        )
 
         if self.diagraph.log_handler:
             log_handler = self.diagraph.log_handler

--- a/packages/python/diagraph/classes/types.py
+++ b/packages/python/diagraph/classes/types.py
@@ -15,3 +15,5 @@ FunctionLogHandler = Callable[[LogEventName, dict | None], None]
 ErrorHandler = Callable[[Exception, Rerunner, Fn], None]
 # TODO: Support arbitrary args and kwargs.
 FunctionErrorHandler = Callable[[Exception, Rerunner], None]
+
+KeyIdentifier = str | Fn

--- a/packages/python/diagraph/utils/depends.py
+++ b/packages/python/diagraph/utils/depends.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from diagraph.classes.types import Fn
+from diagraph.classes.types import Fn, KeyIdentifier
 
 
 def Depends(dependency: Fn) -> Any:
@@ -17,9 +17,9 @@ class FnDependency:
     - dependency (Fn): The dependency to be injected.
     """
 
-    dependency: Fn
+    dependency: KeyIdentifier
 
-    def __init__(self, dependency: Fn):
+    def __init__(self, dependency: KeyIdentifier):
         """
         Initializes a Depends instance with a given dependency.
 

--- a/packages/python/diagraph/utils/get_execution_graph_test.py
+++ b/packages/python/diagraph/utils/get_execution_graph_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from ..classes.diagraph import Diagraph
 from ..classes.graph import Graph
+from ..classes.types import KeyIdentifier
 from .depends import Depends
 from .get_execution_graph import get_execution_graph
 
@@ -201,7 +202,15 @@ def describe_execution_graph():
         ],
     )
     def test_it_gets_execution_graph_for_nodes(graph_def, starting_nodes, expectation):
-        execution_graph = list(get_execution_graph(Graph(graph_def), starting_nodes))
+        def get_key_for_fn(fn: KeyIdentifier):
+            return fn
+            # if type(fn) is Callable:
+            #     return fn
+            # raise Exception(f"Dependency {fn} is a string")
+
+        execution_graph = list(
+            get_execution_graph(Graph(graph_def), starting_nodes, get_key_for_fn),
+        )
 
         try:
             assert execution_graph == expectation
@@ -225,6 +234,8 @@ def describe_execution_graph():
         dg = Diagraph(b, c)
         group = dg[0]
 
-        execution_graph = list(get_execution_graph(dg.__graph__, group))
+        execution_graph = list(
+            get_execution_graph(dg.__graph__, group, dg.get_fn_for_key),
+        )
 
         assert execution_graph == [[a], [b, c]]


### PR DESCRIPTION
More thoroughly embed support for string keys across Diagraph.

This is a necessary precursor to enabling JSON serialization, which requires the use of string keys (as opposed to function identifiers, which will not be consistent between serializations).